### PR TITLE
fix incorrect syntax on examples for rules.rename-tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,9 +163,9 @@ This rules renames a tag from a given measurement
 ```
 [[rules.rename-tag]]
     to="hostname"
-    [measurement.strings]
+    [rules.rename-tag.measurement.strings]
         hasprefix="linux."
-    [tag.strings]
+    [rules.rename-tag.tag.strings]
         equal="host"
 ```
 

--- a/rules/rename_tag.go
+++ b/rules/rename_tag.go
@@ -124,9 +124,9 @@ func (r *RenameTagRule) Apply(key []byte, values []tsm1.Value) ([]byte, []tsm1.V
 func (c *RenameTagRuleConfig) Sample() string {
 	return `
 	to="hostname"
-	[measurement.strings]
+	[rules.rename-tag.measurement.strings]
 		hasprefix="linux."
-	[tag.strings]
+	[rules.rename-tag.tag.strings]
 		equal="host"
 	`
 }


### PR DESCRIPTION
fix incorrect syntax on examples for rules.rename-tag